### PR TITLE
feat: Implement Markdown translator website structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Markdown Translator</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+    <div id="file-list">
+        <!-- File list will be populated here by script.js -->
+    </div>
+    <div id="content-display">
+        <!-- Content will be displayed here by script.js -->
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,118 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const markdownFiles = [
+        "ChatGLM4_20240821.md",
+        "ESTsoft-alan_20230920.md",
+        "README.md",
+        "anthropic-claude-3-haiku_20240712.md",
+        "anthropic-claude-3-opus_20240712.md",
+        "anthropic-claude-3-sonnet_20240306.md",
+        "anthropic-claude-3-sonnet_20240311.md",
+        "anthropic-claude-3.5-sonnet_20240712.md",
+        "anthropic-claude-3.5-sonnet_20240909.md",
+        "anthropic-claude-3.5-sonnet_20241022.md",
+        "anthropic-claude-3.5-sonnet_20241122.md",
+        "anthropic-claude-3.7-sonnet_20250224.md",
+        "anthropic-claude-api-tool-use_20250119.md",
+        "anthropic-claude-opus_20240306.md",
+        "anthropic-claude_2.0_20240306.md",
+        "anthropic-claude_2.1_20240306.md",
+        "bolt.new_20241009.md",
+        "brave-leo-ai_20240601.md",
+        "claude-artifacts_20240620.md",
+        "codeium-windsurf-cascade-R1_20250201.md",
+        "codeium-windsurf-cascade_20241206.md",
+        "colab-ai_20240108.md",
+        "colab-ai_20240511.md",
+        "cursor-ide-agent-claude-sonnet-3.7_20250309.md",
+        "cursor-ide-sonnet_20241224.md",
+        "deepseek.ai_01.md",
+        "devv_20240427.md",
+        "discord-clyde_20230420.md",
+        "discord-clyde_20230519.md",
+        "discord-clyde_20230715.md",
+        "discord-clyde_20230716-1.md",
+        "discord-clyde_20230716-2.md",
+        "gandalf_20230919.md",
+        "github-copilot-chat_20230513.md",
+        "github-copilot-chat_20240930.md",
+        "google-gemini-1.5_20240411.md",
+        "manus_20250309.md",
+        "manus_20250310.md",
+        "microsoft-bing-chat_20230209.md",
+        "microsoft-copilot_20240310.md",
+        "microsoft-copilot_20241219.md",
+        "mistral-le-chat-pro-20250425.md",
+        "moonshot-kimi-chat_20241106.md",
+        "naver-cue_20230920.md",
+        "notion-ai_20221228.md",
+        "openai-assistants-api_20231106.md",
+        "openai-chatgpt-ios_20230614.md",
+        "openai-chatgpt4-android_20240207.md",
+        "openai-chatgpt4o_20240520.md",
+        "openai-chatgpt4o_20250324.md",
+        "openai-chatgpt_20221201.md",
+        "openai-dall-e-3_20231007-1.md",
+        "openai-dall-e-3_20231007-2.md",
+        "openai-deep-research_20250204.md",
+        "opera-aria_20230617.md",
+        "perplexity.ai_20221208.md",
+        "perplexity.ai_20240311.md",
+        "perplexity.ai_20240513.md",
+        "perplexity.ai_20240607.md",
+        "perplexity.ai_20250112.md",
+        "perplexity.ai_gpt4_20240311.md",
+        "phind_20240427.md",
+        "remoteli-io_20230806.md",
+        "roblox-studio-assistant_20240320.md",
+        "snap-myai_20230430.md",
+        "v0_20250306.md",
+        "wrtn-gpt3.5_20240215.md",
+        "wrtn-gpt4_20240215.md",
+        "wrtn_20230603.md",
+        "xAI-grok2_20241218.md",
+        "xAI-grok2_20250111.md",
+        "xAI-grok3_20250223.md",
+        "xAI-grok3_20250423.md",
+        "xAI-grok3_20250504.md",
+        "xAI-grok3_20250509.md",
+        "xAI-grok_20240307.md",
+        "xAI-grok_20241003.md"
+    ];
+
+    const fileListDiv = document.getElementById('file-list');
+    const contentDisplayDiv = document.getElementById('content-display');
+
+    // Placeholder translation function
+    function placeholderTranslate(htmlContent) {
+        return `<h3>[Translated Content (Placeholder)]</h3>${htmlContent}`;
+    }
+
+    const ul = document.createElement('ul');
+    fileListDiv.appendChild(ul);
+
+    markdownFiles.forEach(filename => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = 'javascript:void(0);';
+        a.textContent = filename;
+        a.addEventListener('click', () => {
+            fetch(filename) // Fetch the markdown file
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+                    return response.text();
+                })
+                .then(markdownText => {
+                    const originalHtml = marked.parse(markdownText);
+                    contentDisplayDiv.innerHTML = placeholderTranslate(originalHtml); // Parse, translate (placeholder), and display
+                })
+                .catch(error => {
+                    console.error('Error fetching or parsing markdown:', error);
+                    contentDisplayDiv.innerHTML = `<p>Error loading file: ${filename}. Please check the console for details.</p>`;
+                });
+        });
+        li.appendChild(a);
+        ul.appendChild(li);
+    });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,56 @@
+body {
+    font-family: sans-serif;
+    margin: 0;
+    display: flex; /* Use flexbox for layout */
+    height: 100vh; /* Full viewport height */
+}
+
+#file-list {
+    width: 25%; /* Adjust width as needed */
+    height: 100%;
+    overflow-y: auto; /* Scrollable if content overflows */
+    padding: 15px;
+    border-right: 1px solid #ccc;
+    background-color: #f9f9f9;
+}
+
+#file-list ul {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+#file-list li a {
+    display: block;
+    padding: 8px 10px;
+    text-decoration: none;
+    color: #333;
+    border-bottom: 1px solid #eee;
+}
+
+#file-list li a:hover {
+    background-color: #e9e9e9;
+}
+
+#content-display {
+    width: 75%; /* Adjust width as needed */
+    height: 100%;
+    overflow-y: auto; /* Scrollable if content overflows */
+    padding: 20px;
+    line-height: 1.6;
+}
+
+/* Basic styling for headings and other elements if needed */
+#content-display h1,
+#content-display h2,
+#content-display h3 {
+    color: #333;
+}
+
+#content-display pre { /* Style for code blocks */
+    background-color: #f4f4f4;
+    border: 1px solid #ddd;
+    padding: 10px;
+    border-radius: 4px;
+    overflow-x: auto; /* Scroll long code lines */
+}


### PR DESCRIPTION
Adds an HTML page (`index.html`) to serve as a simple website for viewing Markdown files from the repository.

Key features:
- A navigation panel on the left lists all `.md` files from the repository (hardcoded list for now).
- Clicking a file fetches its content, renders it from Markdown to HTML using `marked.js`.
- A placeholder translation notice "[Translated Content (Placeholder)]" is prepended to the displayed content.
- Basic CSS (`style.css`) is included for layout and readability.
- JavaScript (`script.js`) handles file listing, fetching, rendering, and the placeholder translation.

This setup is intended for deployment via GitHub Pages. You will need to configure GitHub Pages in your repository settings to serve from the root of the main branch.